### PR TITLE
Added ids for register_sidebar

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -26,20 +26,22 @@ if ( function_exists( 'add_image_size' ) ) {
 /* Add widget support */
 if ( function_exists('register_sidebar') )
     register_sidebar(array(
-        'name' => 'SidebarOne',
+        'name'          => 'SidebarOne',
+        'id'            => 'SidebarOne',
 	    'before_widget' => '<div id="%1$s" class="sidebar-widget %2$s">',
-        'after_widget' => '</div>',
-        'before_title' => '<h4 class="widgettitle">',
-        'after_title' => '</h4>',
+        'after_widget'  => '</div>',
+        'before_title'  => '<h4 class="widgettitle">',
+        'after_title'   => '</h4>',
     ));
     
 if ( function_exists('register_sidebar') )
     register_sidebar(array(
-        'name' => 'SidebarTwo',
+        'name'          => 'SidebarTwo',
+        'id'            => 'SidebarTwo',
 	    'before_widget' => '<div id="%1$s" class="sidebar-widget %2$s">',
-        'after_widget' => '</div>',
-        'before_title' => '<h4 class="widgettitle">',
-        'after_title' => '</h4>',
+        'after_widget'  => '</div>',
+        'before_title'  => '<h4 class="widgettitle">',
+        'after_title'   => '</h4>',
     ));
 
 


### PR DESCRIPTION
With debug turned on in wp-config.php: define('WP_DEBUG', true); there were errors displaying on the Themes page
![olympos](https://cloud.githubusercontent.com/assets/1879220/22719581/6eeb687a-eda6-11e6-8a16-70dcd4402246.png)

To fix this the ids were added and all array items aligned in the theme's functions.php.

Now the errors don't show up any more. 

